### PR TITLE
Set Arima version to old release

### DIFF
--- a/transformers/timeseries/auto_arima_forecast.py
+++ b/transformers/timeseries/auto_arima_forecast.py
@@ -14,7 +14,7 @@ from h2oaicore.systemutils import make_experiment_logger, loggerinfo, loggerwarn
 class MyAutoArimaTransformer(CustomTimeSeriesTransformer):
     _binary = False
     _multiclass = False
-    _modules_needed_by_name = ['pmdarima']
+    _modules_needed_by_name = ['pmdarima==1.2']
     _included_model_classes = None
 
     @staticmethod


### PR DESCRIPTION
Old release 1.2 of Arima does not conflict with scipy and numpy DAI 1.8.0 versions