### PR TITLE
Ogre prophet fix

### DIFF
--- a/transformers/timeseries/parallel_auto_arima_forecast.py
+++ b/transformers/timeseries/parallel_auto_arima_forecast.py
@@ -52,7 +52,7 @@ class MyParallelAutoArimaTransformer(CustomTimeSeriesTransformer):
     """Implementation of the ARIMA transformer using a pool of processes to fit models in parallel"""
     _binary = False
     _multiclass = False
-    _modules_needed_by_name = ['pmdarima']
+    _modules_needed_by_name = ['pmdarima==1.2']
     _included_model_classes = None
 
     @staticmethod

--- a/transformers/timeseries/parallel_prophet_forecast.py
+++ b/transformers/timeseries/parallel_prophet_forecast.py
@@ -62,7 +62,9 @@ class MyParallelProphetTransformer(CustomTimeSeriesTransformer):
     def __init__(
             self,
             country_holidays=None,
-            monthly_seasonality=False,  **kwargs):
+            monthly_seasonality=False,
+            **kwargs
+    ):
         super().__init__(**kwargs)
         self.country_holidays = country_holidays
         self.monthly_seasonality = monthly_seasonality
@@ -73,7 +75,7 @@ class MyParallelProphetTransformer(CustomTimeSeriesTransformer):
         if self.country_holidays is not None:
             name += "_Holiday_{}".format(self.country_holidays)
         if self.monthly_seasonality:
-            name += "_MonthlySeason"
+            name += "_Month"
         return name
 
     @staticmethod
@@ -110,7 +112,7 @@ class MyParallelProphetTransformer(CustomTimeSeriesTransformer):
         # Import FB Prophet package
         mod = importlib.import_module('fbprophet')
         Prophet = getattr(mod, "Prophet")
-        model = Prophet()
+        model = Prophet(yearly_seasonality=True, weekly_seasonality=True, daily_seasonality=True)
 
         if params["country_holidays"] is not None:
             model.add_country_holidays(country_name=params["country_holidays"])
@@ -223,7 +225,7 @@ class MyParallelProphetTransformer(CustomTimeSeriesTransformer):
             out[res[0]] = res[1]
 
         pool_to_use = small_job_pool
-        loggerinfo(logger, "Prophet will use {} workers for fitting".format(n_jobs))
+        loggerinfo(logger, f"Prophet will use {n_jobs} workers for fitting.")
         loggerinfo(logger, "Prophet parameters holidays {} / monthly {}".format(self.country_holidays, self.monthly_seasonality))
         pool = pool_to_use(
             logger=None, processor=processor,

--- a/transformers/timeseries/serial_prophet_forecast.py
+++ b/transformers/timeseries/serial_prophet_forecast.py
@@ -62,7 +62,7 @@ class MySerialProphetTransformer(CustomTimeSeriesTransformer):
         for _i_g, (key, X) in enumerate(XX_grp):
             if (100 * (_i_g + 1) // nb_groups) % 5 == 0:
                 print("FB Prophet - ", 100 * (_i_g + 1) // nb_groups, "%% of Groups Fitted")
-            model = Prophet()
+            model = Prophet(yearly_seasonality=True, weekly_seasonality=True, daily_seasonality=True)
             key = key if isinstance(key, list) else [key]
             grp_hash = '_'.join(map(str, key))
             # print("prophet - fitting on data of shape: %s for group: %s" % (str(X.shape), grp_hash))


### PR DESCRIPTION
Set version of Arima to an old release in the parallel transformer.

Set seasonality settings to True in Prophet to avoid 'auto' settings that could lead to different behaviour between a model on a validation split and the final model, i.e. Prophet could chose to not use yearly seasonality during validation and use it when trained on the full train dataset for the final pipeline.
