### PR TITLE
issue-13616-2: Docs: Update to FAQ for custom recipe support with MOJOs

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -66,7 +66,7 @@
   #### How do I delete all recipes on my instance?
   If you really need to delete all recipes, you can delete the `contrib` folder inside the `data_directory` (usually called `tmp`) and restart Driverless AI. Caution: Previously created experiments using custom recipes will not be able to make predictions any longer, so this is not recommended unless you also delete all related experiments as well.
   #### Are MOJOs supported for experiments that use custom recipes?
-  In most cases, MOJOs will not be available for custom recipes. Unless the recipe is simple, creating the MOJO is only possible with additional MOJO runtime support. Contact support@h2o.ai for more information about creating MOJOs for custom recipes. (Note: The Python Scoring Pipeline features full support for custom recipes.)
+  In most cases (especially for complex recipes), MOJOs won’t be available out of the box. But, it is possible to get the MOJO. Contact support@h2o.ai for more information about creating MOJOs for custom recipes. (**Note**: The Python Scoring Pipeline features full support for custom recipes.)
   #### How do I share my recipe with the world?
   We encourage you to share your recipe in this repository. If your recipe works, please make a pull request and improve the experience for everyone!
     


### PR DESCRIPTION
Information about custom recipe support with MOJOs in the driverlessai-recipes repo FAQ has been updated.

https://github.com/h2oai/h2oai/issues/13616