### PR TITLE
Audio to image data recipe

### DIFF
--- a/data/audio_to_image.py
+++ b/data/audio_to_image.py
@@ -1,4 +1,26 @@
-"""Data recipe to transform input audio to mel spectrograms"""
+"""Data recipe to transform input audio to Mel spectrograms
+
+This data recipe makes the following steps:
+1. Reads audio file
+2. Converts audio file to the Mel spectrogram
+3. Save Mel spectrogram to .png image
+4. Upload image dataset to DAI
+
+Recipe is based on the Kaggle Freesound Audio Tagging 2019 challenge:
+https://www.kaggle.com/c/freesound-audio-tagging-2019
+
+To use the recipe follow the next steps:
+1. Download a subsample of the audio dataset from here:
+http://h2o-public-test-data.s3.amazonaws.com/bigdata/server/Image Data/freesound_audio.zip
+2. Unzip it and specify the path to the dataset in the DATA_DIR global variable
+3. Upload the dataset into Driverless AI using the Add Data Recipe option
+
+The transformed dataset is also available and could be directly uploaded to Driverless AI:
+http://h2o-public-test-data.s3.amazonaws.com/bigdata/server/Image Data/freesound_images.zip
+
+"""
+
+DATA_DIR = "/path/to/freesound_audio/"
 
 import cv2
 import os
@@ -18,12 +40,14 @@ class AudioToMelSpectogram:
     https://github.com/lRomul/argus-freesound/blob/master/src/audio.py
     """
 
-    def __init__(self):
+    def __init__(
+        self, min_seconds=2, sampling_rate=44100, n_mels=128, hop_length=345 * 2
+    ):
         # Audio hyperparameters
-        self.min_seconds = 2
-        self.sampling_rate = 44100
-        self.n_mels = 128
-        self.hop_length = 345 * 2
+        self.min_seconds = min_seconds
+        self.sampling_rate = sampling_rate
+        self.n_mels = n_mels
+        self.hop_length = hop_length
         self.n_fft = self.n_mels * 20
         self.fmin = 20
         self.fmax = self.sampling_rate // 2
@@ -78,13 +102,14 @@ class AudioDataset(CustomData):
     """
 
     @staticmethod
-    def create_data(X=None):
+    def create_data():
 
-        # Path to labels. First column is image name, second column is label
-        path_to_labels = "/path/to/labels.csv"
+        # Path to the directory with audios
+        path_to_files = os.path.join(DATA_DIR, "audio/")
+        # Path to a .csv with labels. First column is audio name, second column is label
+        path_to_labels = os.path.join(DATA_DIR, "labels.csv")
 
-        # Data directory
-        path_to_files = "/path/to/audio/"
+        # Create output directory
         output_path = os.path.join(path_to_files, "mel_spectrograms/")
         os.makedirs(output_path, exist_ok=True)
 

--- a/data/audio_to_image.py
+++ b/data/audio_to_image.py
@@ -1,0 +1,113 @@
+"""Data recipe to transform input audio to mel spectrograms"""
+
+import cv2
+import os
+import shutil
+import numpy as np
+import pandas as pd
+from h2oaicore.data import CustomData
+
+_global_modules_needed_by_name = ["librosa==0.8.0"]
+import librosa
+
+
+class AudioToMelSpectogram:
+    """
+    Transforms input audio files into Mel Spectrograms.
+    Audio reading and transformation is mostly taken from here:
+    https://github.com/lRomul/argus-freesound/blob/master/src/audio.py
+    """
+
+    def __init__(self):
+        # Audio hyperparameters
+        self.min_seconds = 2
+        self.sampling_rate = 44100
+        self.n_mels = 128
+        self.hop_length = 345 * 2
+        self.n_fft = self.n_mels * 20
+        self.fmin = 20
+        self.fmax = self.sampling_rate // 2
+
+    def read_audio(self, file_path):
+        min_samples = int(self.min_seconds * self.sampling_rate)
+        y, sr = librosa.load(file_path, sr=self.sampling_rate)
+        # Trim silence
+        trim_y, trim_idx = librosa.effects.trim(y)
+
+        # Pad to min_samples
+        if len(trim_y) < min_samples:
+            padding = min_samples - len(trim_y)
+            offset = padding // 2
+            trim_y = np.pad(trim_y, (offset, padding - offset), "constant")
+        return trim_y
+
+    def audio_to_melspectrogram(self, audio):
+        spectrogram = librosa.feature.melspectrogram(
+            audio,
+            sr=self.sampling_rate,
+            n_mels=self.n_mels,
+            hop_length=self.hop_length,
+            n_fft=self.n_fft,
+            fmin=self.fmin,
+            fmax=self.fmax,
+        )
+        spectrogram = librosa.power_to_db(spectrogram)
+        spectrogram = spectrogram.astype(np.float32)
+        return spectrogram
+
+    def melspectrogram_to_image(self, spectrogram):
+        norm_min = np.min(spectrogram)
+        norm_max = np.max(spectrogram)
+
+        # Normalize to [0, 255] range
+        image = 255 * (spectrogram - norm_min) / (norm_max - norm_min)
+        image = image.astype(np.uint8)
+
+        return image
+
+    def read_as_image(self, file_path):
+        audio = self.read_audio(file_path)
+        mels = self.audio_to_melspectrogram(audio)
+        image = self.melspectrogram_to_image(mels)
+        return image
+
+
+class AudioDataset(CustomData):
+    """
+    Takes input audio files and re-writes them as Mel Spectrogram images
+    """
+
+    @staticmethod
+    def create_data(X=None):
+
+        # Path to labels. First column is image name, second column is label
+        path_to_labels = "/path/to/labels.csv"
+
+        # Data directory
+        path_to_files = "/path/to/audio/"
+        output_path = os.path.join(path_to_files, "mel_spectrograms/")
+        os.makedirs(output_path, exist_ok=True)
+
+        # Read data
+        df = pd.read_csv(path_to_labels)
+        audio_filenames = df.iloc[:, 0]
+
+        # Convert audio to melspectrogram and save as image
+        wav2mel = AudioToMelSpectogram()
+        for idx, audio_name in enumerate(audio_filenames):
+            audio_path = os.path.join(path_to_files, audio_name)
+            image_path = os.path.join(output_path, f"{audio_name}.png")
+            img = wav2mel.read_as_image(audio_path)
+            cv2.imwrite(image_path, img)
+            df.iloc[idx, 0] = f"{audio_name}.png"
+
+        # Save .csv file with labels
+        df.to_csv(os.path.join(output_path, "labels.csv"), index=False)
+
+        # Create .zip archive to upload to DAI
+        shutil.make_archive(
+            os.path.join(path_to_files, "mel_spectrograms"), "zip", output_path
+        )
+        zip_archive_path = os.path.join(path_to_files, "mel_spectrograms.zip")
+
+        return zip_archive_path


### PR DESCRIPTION
This data recipe makes the following steps:
1. Read audio file
2. Convert audio file to mel spectrogram
3. Save mel spectrogram to .png image
4. Upload image dataset to DAI 

Data preparation code is inspired by the [top-1 solution](https://github.com/lRomul/argus-freesound) from the Kaggle [ Freesound Audio Tagging 2019](https://www.kaggle.com/c/freesound-audio-tagging-2019) challenge. As well as, by [this](https://www.kaggle.com/daisukelab/creating-fat2019-preprocessed-data) nice data preparation notebook.

Here is the experiment example for the Freesound competition. Note, that we consider only single-label observations for DAI.
<img width="1160" alt="Screen Shot 2020-07-24 at 11 53 50" src="https://user-images.githubusercontent.com/25034016/88381453-c022e900-cda6-11ea-8fe9-a9f944a25eca.png">
<img width="1172" alt="Screen Shot 2020-07-24 at 12 23 09" src="https://user-images.githubusercontent.com/25034016/88382367-9c60a280-cda8-11ea-8b0f-e78b58c337dd.png">
<img width="1037" alt="Screen Shot 2020-07-24 at 12 23 41" src="https://user-images.githubusercontent.com/25034016/88382380-a08cc000-cda8-11ea-9f54-eb0baa2e1602.png">


