### PR TITLE
Update text_binary_count_transformer.py

### DIFF
--- a/transformers/nlp/text_binary_count_transformer.py
+++ b/transformers/nlp/text_binary_count_transformer.py
@@ -75,8 +75,7 @@ class TextBinaryCountTransformer(CustomTransformer):
                                          stop_words=self.remove_stopwords
                                          )
         X = self.count_vec.fit_transform(X).toarray()
-        self._output_feature_names = ['BinaryCount:' + curr_col + '.' + token.replace(' ', '_') for token in
-                                      self.count_vec.get_feature_names()]
+        self._output_feature_names = ['BinaryCount:' + curr_col + '.' + token for token in self.count_vec.get_feature_names()]
         self._feature_desc = ["Binary count of '" + token + "' found in " + curr_col for token in
                               self.count_vec.get_feature_names()]
         return X


### PR DESCRIPTION
Removed .replace(' ', '_') from line 78 (causing failed tests of multiple features/tokens to have the same name, e.g. `live_in_super` and `line in super` will clash)