### PR TITLE
Add datatable GLM recipe

### DIFF
--- a/models/algorithms/datatable_glm.py
+++ b/models/algorithms/datatable_glm.py
@@ -1,0 +1,48 @@
+"""datatable Linear Model"""
+from h2oaicore.models import CustomModel
+from datatable import dt, models, f
+import numpy as np
+
+
+class datatableLinearModel(CustomModel):
+    _regression = True
+    _binary = True
+    _multiclass = True
+    _display_name = "datatableLinearModel"
+    _description = "datatable Linear Model"
+
+    def fit(self, X, y, sample_weight=None, eval_set=None, sample_weight_eval_set=None, **kwargs):
+        if self.num_classes == 1:
+            model_type = "regression"
+        elif self.num_classes == 2:
+            model_type = "binomial"
+        else:
+            model_type = "multinomial"
+
+        lm = dt.models.LinearModel(model_type=model_type)
+        y = dt.Frame(y)
+        X_mean = X.mean()
+        X_sd = X.sd()
+        X_standard = X[:, (f[:] - X_mean)/X_sd]
+        X_standard.replace(None, 0.0)
+
+        res = lm.fit(X_standard, y)
+        importances = lm.model[:, dt.rowsum(dt.math.abs(f[:]))]
+        model = {"lm": lm, "X_mean": X_mean, "X_sd": X_sd}
+
+        self.set_model_properties(model=model,
+                                  features=X.names,
+                                  importances=importances.to_list()[0],
+                                  iterations=res.epoch)
+
+
+    def predict(self, X, **kwargs):
+        model, _, _, _ = self.get_model_properties()
+        X_standard = X[:, (f[:] - model["X_mean"])/model["X_sd"]]
+        X_standard.replace(None, 0.0)
+
+        p = model["lm"].predict(X_standard)
+        p_np = p.to_numpy()
+
+        return p_np
+

--- a/models/algorithms/datatable_glm.py
+++ b/models/algorithms/datatable_glm.py
@@ -40,9 +40,11 @@ class datatableLinearModel(CustomModel):
         model, _, _, _ = self.get_model_properties()
         X_standard = X[:, (f[:] - model["X_mean"])/model["X_sd"]]
         X_standard.replace(None, 0.0)
-
         p = model["lm"].predict(X_standard)
-        p_np = p.to_numpy()
 
-        return p_np
+        #TODO: remove conversion to numpy, as we should support returning of dt frames
+        #https://github.com/h2oai/driverlessai-recipes/blob/0da78f9252a40f1382c63cb22e4d314f9e8c982e/models/model_template.py#L329
+        p = p.to_numpy()
+
+        return p
 


### PR DESCRIPTION
An initial implementation of the datatable GLM recipe that is based on the datatable's [LinearModel](https://datatable.readthedocs.io/en/latest/api/models/linear_model.html). Supports regression, binomial and multinomial classifications. It also passes all the acceptance tests, however, is not tested thoroughly on realistic datasets in DAI. This is currently WIP.