### PR TITLE
Fix numpy array when creating inhomogeneous shaped array and update `nltk` for Python 3.11

### DIFF
--- a/data/nlp/sentiment_score.py
+++ b/data/nlp/sentiment_score.py
@@ -10,7 +10,7 @@ text_colnames = ["text"]
 # output dataset name
 output_dataset_name = "df_with_sentiment"
 
-_global_modules_needed_by_name = ['nltk==3.4.3', "textblob"]
+_global_modules_needed_by_name = ['nltk==3.8.1', "textblob"]
 
 
 class SentimentScoreClass(CustomData):

--- a/models/algorithms/h2o-3-models.py
+++ b/models/algorithms/h2o-3-models.py
@@ -734,11 +734,11 @@ class H2ODLModel(H2OBaseModel, CustomModel):
         self.params['activation'] = np.random.choice(["rectifier", "rectifier",  # upweight
                                                       "rectifier_with_dropout",
                                                       "tanh"])
-        self.params['hidden'] = np.random.choice([[20, 20, 20],
+        self.params['hidden'] = np.random.choice(np.array([[20, 20, 20],
                                                   [50, 50, 50],
                                                   [100, 100, 100],
                                                   [200, 200], [200, 200, 200],
-                                                  [500], [500, 500], [500, 500, 500]])
+                                                  [500], [500, 500], [500, 500, 500]], dtype='object'))
         self.params['epochs'] = accuracy * max(1, time_tolerance)
         if config.hard_asserts:
             # avoid long times for testing

--- a/models/unsupervised/TextSentiment.py
+++ b/models/unsupervised/TextSentiment.py
@@ -8,7 +8,7 @@ import numpy as np
 
 class TextSentimentTransformer(CustomUnsupervisedTransformer):
     _testing_can_skip_failure = False  # ensure tested as if shouldn't fail
-    _modules_needed_by_name = ['nltk==3.4.3', 'textblob']
+    _modules_needed_by_name = ['nltk==3.8.1', 'textblob']
 
     @staticmethod
     def get_default_properties():

--- a/transformers/nlp/fuzzy_text_similarity_transformers.py
+++ b/transformers/nlp/fuzzy_text_similarity_transformers.py
@@ -5,12 +5,12 @@ from h2oaicore.transformer_utils import CustomTransformer
 import datatable as dt
 import numpy as np
 
-_global_modules_needed_by_name = ['nltk==3.4.3']
+_global_modules_needed_by_name = ['nltk==3.8.1']
 import nltk
 
 
 class FuzzyBaseTransformer:
-    _modules_needed_by_name = ['fuzzywuzzy==0.17.0']
+    _modules_needed_by_name = ['fuzzywuzzy==0.18.0']
     _method = NotImplemented
     _parallel_task = False
     _testing_can_skip_failure = False  # ensure tested as if shouldn't fail


### PR DESCRIPTION
Fixes 
1. The following error in DriverlessAI.
```
[2024-04-10T07:26:07.382Z]   File "tmp/h2oai/contrib1/models/custom_models.py", line 729, in set_default_params
[2024-04-10T07:26:07.382Z]     self.mutate_params(accuracy=accuracy, time_tolerance=time_tolerance, **kwargs)
[2024-04-10T07:26:07.382Z]   File "tmp/h2oai/contrib1/models/custom_models.py", line 737, in mutate_params
[2024-04-10T07:26:07.382Z]     self.params['hidden'] = np.random.choice([[20, 20, 20],
[2024-04-10T07:26:07.382Z]                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2024-04-10T07:26:07.382Z]   File "numpy/random/mtrand.pyx", line 937, in numpy.random.mtrand.RandomState.choice
[2024-04-10T07:26:07.382Z] ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (8,) + inhomogeneous part.
```

2. Upgrade `nltk` for Python 3.11 support

4. and 
```
For Package nltk, DAI has version 3.8.1 and user request is 3.4.3 and must be same or do not make user request.
```