### PR TITLE
Migrate call to label_binarize to scikit-learn 1.1.3

### DIFF
--- a/scorers/classification/binary/balanced_accuracy.py
+++ b/scorers/classification/binary/balanced_accuracy.py
@@ -42,7 +42,7 @@ class balancedaccuracy(CustomScorer):
         # multiclass
         if enc_predicted.shape[1] > 1:
             enc_predicted = enc_predicted.ravel()
-            enc_actual = label_binarize(enc_actual, labels).ravel()
+            enc_actual = label_binarize(enc_actual, classes=labels).ravel()
             cm_weights = np.repeat(cm_weights, predicted.shape[1]).ravel() if cm_weights is not None else None
             assert enc_predicted.shape == enc_actual.shape
             assert cm_weights is None or enc_predicted.shape == cm_weights.shape

--- a/scorers/classification/binary/cost.py
+++ b/scorers/classification/binary/cost.py
@@ -45,7 +45,7 @@ class CostBinary(CustomScorer):
         # multiclass
         if enc_predicted.shape[1] > 1:
             enc_predicted = enc_predicted.ravel()
-            enc_actual = label_binarize(enc_actual, labels).ravel()
+            enc_actual = label_binarize(enc_actual, classes=labels).ravel()
             cm_weights = np.repeat(cm_weights, predicted.shape[1]).ravel() if cm_weights is not None else None
             assert enc_predicted.shape == enc_actual.shape
             assert cm_weights is None or enc_predicted.shape == cm_weights.shape

--- a/scorers/classification/binary/cost_access_to_data.py
+++ b/scorers/classification/binary/cost_access_to_data.py
@@ -53,7 +53,7 @@ class CostBinaryWithData(CustomScorer):
         # multiclass
         if enc_predicted.shape[1] > 1:
             enc_predicted = enc_predicted.ravel()
-            enc_actual = label_binarize(enc_actual, labels).ravel()
+            enc_actual = label_binarize(enc_actual, classes=labels).ravel()
             cm_weights = np.repeat(cm_weights, predicted.shape[1]).ravel() if cm_weights is not None else None
             assert enc_predicted.shape == enc_actual.shape
             assert cm_weights is None or enc_predicted.shape == cm_weights.shape

--- a/scorers/classification/binary/profit.py
+++ b/scorers/classification/binary/profit.py
@@ -68,7 +68,7 @@ class ProfitWithData(CustomScorer):
         # multiclass
         if enc_predicted.shape[1] > 1:
             enc_predicted = enc_predicted.ravel()
-            enc_actual = label_binarize(enc_actual, labels).ravel()
+            enc_actual = label_binarize(enc_actual, classes=labels).ravel()
             cm_weights = np.repeat(cm_weights, predicted.shape[1]).ravel() if cm_weights is not None else None
             assert enc_predicted.shape == enc_actual.shape
             assert cm_weights is None or enc_predicted.shape == cm_weights.shape

--- a/scorers/classification/f3_score.py
+++ b/scorers/classification/f3_score.py
@@ -42,7 +42,7 @@ class F3Scorer(CustomScorer):
         # multiclass
         if enc_predicted.shape[1] > 1:
             enc_predicted = enc_predicted.ravel()
-            enc_actual = label_binarize(enc_actual, labels).ravel()
+            enc_actual = label_binarize(enc_actual, classes=labels).ravel()
             cm_weights = np.repeat(cm_weights, predicted.shape[1]).ravel() if cm_weights is not None else None
             assert enc_predicted.shape == enc_actual.shape
             assert cm_weights is None or enc_predicted.shape == cm_weights.shape

--- a/scorers/classification/f4_score.py
+++ b/scorers/classification/f4_score.py
@@ -42,7 +42,7 @@ class F4Scorer(CustomScorer):
         # multiclass
         if enc_predicted.shape[1] > 1:
             enc_predicted = enc_predicted.ravel()
-            enc_actual = label_binarize(enc_actual, labels).ravel()
+            enc_actual = label_binarize(enc_actual, classes=labels).ravel()
             cm_weights = np.repeat(cm_weights, predicted.shape[1]).ravel() if cm_weights is not None else None
             assert enc_predicted.shape == enc_actual.shape
             assert cm_weights is None or enc_predicted.shape == cm_weights.shape

--- a/scorers/classification/probF.py
+++ b/scorers/classification/probF.py
@@ -109,7 +109,7 @@ class ProbF1Opt2(CustomScorer):
         # multiclass
         if enc_predicted.shape[1] > 1:
             enc_predicted = enc_predicted.ravel()
-            enc_actual = label_binarize(enc_actual, labels).ravel()
+            enc_actual = label_binarize(enc_actual, classes=labels).ravel()
             cm_weights = np.repeat(cm_weights, predicted.shape[1]).ravel() if cm_weights is not None else None
             assert enc_predicted.shape == enc_actual.shape
             assert cm_weights is None or enc_predicted.shape == cm_weights.shape


### PR DESCRIPTION
Fixes DAI tests that are failing with the error

```
[2024-04-11T01:34:38.293Z] Traceback (most recent call last):
[2024-04-11T01:34:38.293Z]   File "/h2oai/h2oaicore/metrics.py", line 666, in test_scorer
[2024-04-11T01:34:38.293Z]     self.test_scorer_sanity(actuals1, preds1, None, labels1)
[2024-04-11T01:34:38.293Z]   File "/h2oai/h2oaicore/metrics.py", line 939, in test_scorer_sanity
[2024-04-11T01:34:38.293Z]     ret = self.score_base(actual=actuals, predicted=preds, sample_weight=sample_weight, labels=labels, **kwargs)
[2024-04-11T01:34:38.293Z]           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2024-04-11T01:34:38.293Z]   File "/h2oai/h2oaicore/metrics.py", line 212, in score_base
[2024-04-11T01:34:38.293Z]     score = self.score(actual=actual, predicted=predicted,
[2024-04-11T01:34:38.293Z]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2024-04-11T01:34:38.293Z]   File "/h2oai/tests/contrib/scorers/custom_scorers.py", line 605, in score
[2024-04-11T01:34:38.293Z]     enc_actual = label_binarize(enc_actual, labels).ravel()
[2024-04-11T01:34:38.293Z]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2024-04-11T01:34:38.293Z] TypeError: label_binarize() takes 1 positional argument but 2 were given
```