### PR TITLE
Update code to work with new numpy and pandas versions

### DIFF
--- a/data/unsupervised/KMeansClustering.py
+++ b/data/unsupervised/KMeansClustering.py
@@ -98,7 +98,7 @@ def my_davies_bouldin_score(X, labels):
     check_number_of_labels(n_labels, n_samples)
 
     intra_dists = np.zeros(n_labels)
-    centroids = np.zeros((n_labels, len(X[0])), dtype=np.float)
+    centroids = np.zeros((n_labels, len(X[0])), dtype=float)
     for k in range(n_labels):
         cluster_k = safe_indexing(X, labels == k)
         centroid = cluster_k.mean(axis=0)

--- a/data/unsupervised/KmodesRecipe.py
+++ b/data/unsupervised/KmodesRecipe.py
@@ -92,7 +92,7 @@ def my_davies_bouldin_score(X, labels):
     check_number_of_labels(n_labels, n_samples)
 
     intra_dists = np.zeros(n_labels)
-    centroids = np.zeros((n_labels, len(X[0])), dtype=np.float)
+    centroids = np.zeros((n_labels, len(X[0])), dtype=float)
     for k in range(n_labels):
         cluster_k = safe_indexing(X, labels == k)
         centroid = cluster_k.mean(axis=0)

--- a/data/video_to_image.py
+++ b/data/video_to_image.py
@@ -65,7 +65,7 @@ class VideoToFrames:
         # Select only self.num_frames_per_video uniform frames
         n_frames = int(orig_capture.get(cv2.CAP_PROP_FRAME_COUNT))
         frames_idx = np.linspace(
-            0, n_frames, self.num_frames_per_video, endpoint=False, dtype=np.int
+            0, n_frames, self.num_frames_per_video, endpoint=False, dtype=int
         )
 
         # Loop through all frames

--- a/models/algorithms/h2o-3-models.py
+++ b/models/algorithms/h2o-3-models.py
@@ -369,9 +369,9 @@ class H2OBaseModel:
                 is_final = 'IS_FINAL' in kwargs
                 json_file = os.path.join(exp_dir(), 'coefficients_table_is_final_%s_%s.json' % (is_final, struuid))
                 with open(json_file, "wt") as f:
-                    pd.set_option('precision', 16)
+                    pd.set_option('display.precision', 16)
                     f.write(json.dumps(json.loads(coeff_table.to_json()), indent=4))
-                    pd.set_option('precision', 6)
+                    pd.set_option('display.precision', 6)
 
             if isinstance(model, H2OAutoML):
                 pd.set_option('display.max_rows', None)
@@ -531,9 +531,9 @@ class H2OBaseModel:
                 if self.doing_p_values():
                     df = preds.iloc[:, 1]
                     with open(json_file, "wt") as f:
-                        pd.set_option('precision', 16)
+                        pd.set_option('display.precision', 16)
                         f.write(json.dumps(json.loads(df.to_json()), indent=4))
-                        pd.set_option('precision', 6)
+                        pd.set_option('display.precision', 6)
                     return preds.iloc[:, 0].values.ravel()
                 else:
                     return preds.values.ravel()
@@ -541,9 +541,9 @@ class H2OBaseModel:
                 if self.doing_p_values():
                     df = preds.iloc[:, 2]
                     with open(json_file, "wt") as f:
-                        pd.set_option('precision', 16)
+                        pd.set_option('display.precision', 16)
                         f.write(json.dumps(json.loads(df.to_json()), indent=4))
-                        pd.set_option('precision', 6)
+                        pd.set_option('display.precision', 6)
                     return preds.iloc[:, -1 - 1].values.ravel()
                 else:
                     return preds.iloc[:, -1].values.ravel()

--- a/transformers/datetime/datetime_encoder_transformer.py
+++ b/transformers/datetime/datetime_encoder_transformer.py
@@ -19,4 +19,4 @@ class MyDateTimeTransformer(CustomTransformer):
 
     def transform(self, X: dt.Frame):
         X = pd.to_datetime(X.to_pandas().iloc[:, 0], format=self.datetime_formats[self.input_feature_names[0]])
-        return X.fillna(pd.Timestamp(year=1970, month=1, day=1)).astype(np.int)
+        return X.fillna(pd.Timestamp(year=1970, month=1, day=1)).astype(int)

--- a/transformers/transformer_template.py
+++ b/transformers/transformer_template.py
@@ -211,7 +211,7 @@ class CustomTransformer(DataTableTransformer):
 
            y (:obj:`np.array`): The target column. Required. Defaults to None for API compatibility.
                 Shape is (N,)
-                Is of type :obj:`np.float` (regression) or :obj:`np.int` (multiclass) or :obj:`np.bool` (binary)
+                Is of type :obj:`float` (regression) or :obj:`int` (multiclass) or :obj:`bool` (binary)
 
 
         Returns:


### PR DESCRIPTION
Fixes the following error due to API changes in `pandas`
```
[2024-04-12T07:37:09.585Z]   File "/minicondadai_py311/lib/python3.11/site-packages/pandas/_config/config.py", line 123, in _get_single_key
[2024-04-12T07:37:09.585Z]     raise OptionError("Pattern matched multiple keys")
[2024-04-12T07:37:09.585Z] pandas._config.config.OptionError: Pattern matched multiple keys
```

Numpy removed aliases to builtin types, see https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations