### PR TITLE
fix call to brier_score_loss (scikit-learn)

### DIFF
--- a/scorers/classification/binary/brier_loss.py
+++ b/scorers/classification/binary/brier_loss.py
@@ -22,4 +22,4 @@ class MyBrierLoss(CustomScorer):
         lb = LabelEncoder()
         labels = lb.fit_transform(labels)
         actual = lb.transform(actual)
-        return brier_score_loss(actual, predicted, sample_weight, pos_label=labels[1])
+        return brier_score_loss(actual, predicted, sample_weight=sample_weight, pos_label=labels[1])


### PR DESCRIPTION
Fixes

```
brier_score_loss() takes 2 positional arguments but 3 positional arguments (and 1 keyword-only argument) were given
```