### PR TITLE
Fix `POSTagTransformer`, `TextPreprocessingTransformer` recipes

### DIFF
--- a/transformers/nlp/text_pos_tagging_transformer.py
+++ b/transformers/nlp/text_pos_tagging_transformer.py
@@ -23,7 +23,7 @@ class POSTagTransformer:
         nltk.download('averaged_perceptron_tagger', download_dir=nltk_data_path)
         try:
             self.pos_tagger = nltk.pos_tag
-            self.pos_tagger("test")
+            self.pos_tagger(["test"])
         except LookupError:
             os.makedirs(nltk_data_path, exist_ok=True)
             os.makedirs(nltk_temp_path, exist_ok=True)
@@ -40,7 +40,7 @@ class POSTagTransformer:
             self.atomic_copy(file1, tagger_path)
             self.atomic_copy(file2, tagger_path)
             self.pos_tagger = nltk.pos_tag
-            self.pos_tagger("test")
+            self.pos_tagger(["test"])
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/transformers/nlp/text_pos_tagging_transformer.py
+++ b/transformers/nlp/text_pos_tagging_transformer.py
@@ -23,7 +23,7 @@ class POSTagTransformer:
         nltk.download('averaged_perceptron_tagger', download_dir=nltk_data_path)
         try:
             self.pos_tagger = nltk.pos_tag
-            self.pos_tagger(["test"])
+            self.pos_tagger(list("test"))
         except LookupError:
             os.makedirs(nltk_data_path, exist_ok=True)
             os.makedirs(nltk_temp_path, exist_ok=True)
@@ -40,7 +40,7 @@ class POSTagTransformer:
             self.atomic_copy(file1, tagger_path)
             self.atomic_copy(file2, tagger_path)
             self.pos_tagger = nltk.pos_tag
-            self.pos_tagger(["test"])
+            self.pos_tagger(list("test"))
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/transformers/nlp/text_preprocessing_transformer.py
+++ b/transformers/nlp/text_preprocessing_transformer.py
@@ -65,7 +65,7 @@ class TextPreprocessingTransformer(CustomTransformer):
                 self.lemmatizer = nltk.stem.WordNetLemmatizer()
                 self.pos_tagger = nltk.pos_tag
                 self.lemmatizer.lemmatize("test", wordnet.NOUN)
-                self.pos_tagger("test")
+                self.pos_tagger(["test"])
             except LookupError:
                 os.makedirs(nltk_data_path, exist_ok=True)
                 os.makedirs(nltk_temp_path, exist_ok=True)
@@ -92,7 +92,7 @@ class TextPreprocessingTransformer(CustomTransformer):
                 self.lemmatizer = nltk.stem.WordNetLemmatizer()
                 self.pos_tagger = nltk.pos_tag
                 self.lemmatizer.lemmatize("test", wordnet.NOUN)
-                self.pos_tagger("test")
+                self.pos_tagger(["test"])
             self.wordnet_map = {"N": wordnet.NOUN,
                                 "V": wordnet.VERB,
                                 "J": wordnet.ADJ,

--- a/transformers/nlp/text_preprocessing_transformer.py
+++ b/transformers/nlp/text_preprocessing_transformer.py
@@ -65,7 +65,7 @@ class TextPreprocessingTransformer(CustomTransformer):
                 self.lemmatizer = nltk.stem.WordNetLemmatizer()
                 self.pos_tagger = nltk.pos_tag
                 self.lemmatizer.lemmatize("test", wordnet.NOUN)
-                self.pos_tagger(["test"])
+                self.pos_tagger(list("test"))
             except LookupError:
                 os.makedirs(nltk_data_path, exist_ok=True)
                 os.makedirs(nltk_temp_path, exist_ok=True)
@@ -92,7 +92,7 @@ class TextPreprocessingTransformer(CustomTransformer):
                 self.lemmatizer = nltk.stem.WordNetLemmatizer()
                 self.pos_tagger = nltk.pos_tag
                 self.lemmatizer.lemmatize("test", wordnet.NOUN)
-                self.pos_tagger(["test"])
+                self.pos_tagger(list("test"))
             self.wordnet_map = {"N": wordnet.NOUN,
                                 "V": wordnet.VERB,
                                 "J": wordnet.ADJ,


### PR DESCRIPTION
`nltk` package got update to v3.8.1 in https://github.com/h2oai/driverlessai-recipes/commit/706451e7f6a9cdebaf23948b1a5cfd49ba82e96b. Behaviour of the `nltk.pos_tagger` function has changed between [v3.4.3](https://github.com/nltk/nltk/blob/3.4.3/nltk/tag/__init__.py#L111-L162) and [v3.8.1](https://github.com/nltk/nltk/blob/3.8.1/nltk/tag/__init__.py#L111-L166). Now `nltk.pos_tagger` expects a list of string for the `token` parameter (see https://www.nltk.org/api/nltk.tag.html#nltk.tag.pos_tag). 

This is to fix following failure
```
Traceback (most recent call last):,
  File "h2oaicore/genes.py", line 1830, in h2oaicore.genes.Gene.make_transformer,
  File "tmp/h2oai/contrib9/transformers/text_pos_tagging_transformer_117f7ad9_content.py", line 48, in __init__,
    self.set_tagger(),
  File "tmp/h2oai/contrib9/transformers/text_pos_tagging_transformer_117f7ad9_content.py", line 26, in set_tagger,
    self.pos_tagger("test"),
  File "/h2oai/tmp/h2oai/contrib9/env/lib/python3.11/site-packages/nltk/tag/__init__.py", line 166, in pos_tag,
    return _pos_tag(tokens, tagset, tagger, lang),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^,
  File "/h2oai/tmp/h2oai/contrib9/env/lib/python3.11/site-packages/nltk/tag/__init__.py", line 120, in _pos_tag,
    raise TypeError("tokens: expected a list of strings, got a string"),
TypeError: tokens: expected a list of strings, got a string,
```