### PR TITLE
Upgrade spacy to the latest be py311 compatible 

### DIFF
--- a/transformers/nlp/text_named_entities_transformer.py
+++ b/transformers/nlp/text_named_entities_transformer.py
@@ -31,8 +31,8 @@ class TextNamedEntityTransformer(CustomTransformer):
             '%s/wasabi-0.8.2%s' % (_root_path, _suffix),
         ]
     else:
-        _modules_needed_by_name = ["spacy==3.7.4",
-                                   "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.2.5/en_core_web_sm-2.2.5.tar.gz#egg=en_core_web_sm==2.2.5"]
+        _modules_needed_by_name = ["spacy==3.7.5",
+                                   "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.0/en_core_web_sm-3.7.0.tar.gz#egg=en_core_web_sm==3.7.0"]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -57,7 +57,6 @@ class TextNamedEntityTransformer(CustomTransformer):
         return self.transform(X)
 
     def transform(self, X: dt.Frame):
-        import spacy
         import en_core_web_sm
         nlp = en_core_web_sm.load()
 


### PR DESCRIPTION
Title is self-explanatory, upgrading spacy be py311 compatible for e2e test

```
'Module: False_custom_transformers_33c791b1_contenttransformers File: tmp/h2oai/contrib3/transformers/custom_transformers_33c791b1_content.py \nconcurrent.futures.process._RemoteTraceback: \n"""\nconcurrent.futures.process._RemoteTraceback: \n"""\nTraceback (most recent call last):\n  File "h2oaicore/systemutils.py", line 8523, in h2oaicore.systemutils.__traced_func\n  File "h2oaicore/transformer_utils.py", line 1754, in h2oaicore.transformer_utils.fit_transform_safe_state_wrapper\n  File "h2oaicore/transformer_utils.py", line 704, in h2oaicore.transformer_utils.Transformer.fit_transform_base\n  File "h2oaicore/transformer_utils.py", line 663, in h2oaicore.transformer_utils.Transformer.fit_transform_base\n  File "tmp/h2oai/contrib3/transformers/custom_transformers_33c791b1_content.py", line 6434, in fit_transform\n    return self.transform(X)\n           ^^^^^^^^^^^^^^^^^\n  File "tmp/h2oai/contrib3/transformers/custom_transformers_33c791b1_content.py", line 6439, in transform\n    nlp = en_core_web_sm.load()\n          ^^^^^^^^^^^^^^^^^^^^^\n  File "/h2oai/tmp/h2oai/contrib3/env/lib/python3.11/site-packages/en_core_web_sm/__init__.py", line 12, in load\n    return load_model_from_init_py(__file__, **overrides)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/h2oai/tmp/h2oai/contrib3/env/lib/python3.11/site-packages/spacy/util.py", line 682, in load_model_from_init_py\n    return load_model_from_path(\n           ^^^^^^^^^^^^^^^^^^^^^\n  File "/h2oai/tmp/h2oai/contrib3/env/lib/python3.11/site-packages/spacy/util.py", line 538, in load_model_from_path\n    config = load_config(config_path, overrides=overrides)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/h2oai/tmp/h2oai/contrib3/env/lib/python3.11/site-packages/spacy/util.py", line 714, in load_config\n    raise IOError(Errors.E053.format(path=config_path, name="config file"))\nOSError: [E053] Could not read config file from /h2oai/tmp/h2oai/contrib3/env/lib/python3.11/site-packages/en_core_web_sm/en_core_web_sm-2.2.5/config.cfg\n\nDuring handling of the above exception, another exception 
```