### PR TITLE
Fix `CalibratedClassifierModel` recipe

### DIFF
--- a/models/algorithms/calibratedClassifier.py
+++ b/models/algorithms/calibratedClassifier.py
@@ -181,8 +181,7 @@ class CalibratedClassifierModel:
             import ml_insights as mli
             self.calib_method = "spline"
             spline = mli.SplineCalib(
-                penalty='l2',
-                solver='liblinear',
+                method="L-BFGS-B",
                 reg_param_vec='default',
                 cv_spline=3, random_state=4451,
                 knot_sample_size=30,

--- a/models/algorithms/calibratedClassifier.py
+++ b/models/algorithms/calibratedClassifier.py
@@ -196,7 +196,10 @@ class CalibratedClassifierModel:
             spline.fit(preds, y_calibrate, verbose=False)  # no weight support so far :(
 
             self.calib_logodds_scale = spline.logodds_scale
-            self.calib_logodds_eps = spline.logodds_eps
+            # Due to a bug in `splinecalib`, `logodds_eps` attribute doesn't get set
+            # unless you pass the `logodds_eps` param to the `SplineCalib` constructor.
+            # Below we try to mimic the behaviour of `ml_insights` < v1.0.
+            self.calib_logodds_eps = getattr(spline, "logodds_eps", 0.001)
 
             self.calib_knot_vec_tr = []
             self.calib_basis_coef_vec = []

--- a/models/algorithms/calibratedClassifier.py
+++ b/models/algorithms/calibratedClassifier.py
@@ -156,7 +156,7 @@ class CalibratedClassifierModel:
                 self.slope = []
                 self.intercept = []
 
-                for c in calibrator.calibrated_classifiers_[0].calibrators_:
+                for c in calibrator.calibrated_classifiers_[0].calibrators:
                     self.slope.append(c.a_)
                     self.intercept.append(c.b_)
 
@@ -166,7 +166,7 @@ class CalibratedClassifierModel:
 
                 self.X_min_ = []
                 self.X_max_ = []
-                for c in calibrator.calibrated_classifiers_[0].calibrators_:
+                for c in calibrator.calibrated_classifiers_[0].calibrators:
                     self._necessary_X_.append(c.X_thresholds_)
                     self._necessary_y_.append(c.y_thresholds_)
 


### PR DESCRIPTION
- In `scikit-learn`, `calibrators_` attribute in the `_CalibratedClassifier` class has been renamed into `calibrators` (see https://github.com/scikit-learn/scikit-learn/commit/8471c8389d794309b0b62a353e3af903acd48223). This cased `AttributeError: '_CalibratedClassifier' object has no attribute 'calibrators_'` when using the `CalibratedClassifierModel` recipe. This PR renames the usages of `calibrators_` attribute to `calibrators` to fix that error.
- In `ml_insights`, `SplineCalib` class constructor has changed. The `penalty`, `solver` params have been removed and `method` param has been added. (see https://github.com/numeristical/introspective/commit/9d4f5be0b159269bf61d66a0364b151f9aec5584#diff-6298dc7bfb7d0111ff50669c3514cc651dbfdc201be31e81d1d697df1db9df8f, https://github.com/numeristical/splinecalib/commit/45dc522c000c8e90243ce7d5024bc26b2f211f36#diff-b39b488cbeef80f1d0137a05757ab135c3037ea3129c140eb108b26458c89625). Hence this PR changes the `SplineCalib` constructor call accordingly. 