### PR TITLE
Upgrade h2o version to 3.46.0.4

### DIFF
--- a/models/algorithms/h2o-3-gbm-poisson.py
+++ b/models/algorithms/h2o-3-gbm-poisson.py
@@ -11,7 +11,7 @@ from h2o.estimators.gbm import H2OGradientBoostingEstimator
 
 import numpy as np
 
-_global_modules_needed_by_name = ['h2o==3.46.0.2']
+_global_modules_needed_by_name = ['h2o==3.46.0.4']
 import h2o
 import os
 

--- a/models/algorithms/h2o-3-models.py
+++ b/models/algorithms/h2o-3-models.py
@@ -12,7 +12,7 @@ from h2oaicore.systemutils import config, user_dir, remove, IgnoreEntirelyError,
 import numpy as np
 import pandas as pd
 
-_global_modules_needed_by_name = ['h2o==3.46.0.2']
+_global_modules_needed_by_name = ['h2o==3.46.0.4']
 import h2o
 import os
 

--- a/models/algorithms/h2o-glm-poisson.py
+++ b/models/algorithms/h2o-glm-poisson.py
@@ -9,7 +9,7 @@ import uuid
 from h2oaicore.systemutils import config, user_dir, remove, IgnoreEntirelyError
 import numpy as np
 
-_global_modules_needed_by_name = ['h2o==3.46.0.2']
+_global_modules_needed_by_name = ['h2o==3.46.0.4']
 import h2o
 import os
 

--- a/transformers/anomaly /isolation_forest.py
+++ b/transformers/anomaly /isolation_forest.py
@@ -15,7 +15,7 @@ import datatable as dt
 from h2oaicore.systemutils import config, user_dir, remove, IgnoreEntirelyError, print_debug
 from h2oaicore.transformer_utils import CustomTransformer
 
-_global_modules_needed_by_name = ['h2o==3.46.0.2']
+_global_modules_needed_by_name = ['h2o==3.46.0.4']
 import h2o
 from h2o import H2OFrame
 from h2o.estimators import H2OEstimator

--- a/transformers/survival/h2o-3-coxph-pretransformer.py
+++ b/transformers/survival/h2o-3-coxph-pretransformer.py
@@ -10,7 +10,7 @@ from sklearn.preprocessing import LabelEncoder
 import os
 import uuid
 
-_global_modules_needed_by_name = ['h2o==3.46.0.2']
+_global_modules_needed_by_name = ['h2o==3.46.0.4']
 import h2o
 from h2oaicore.systemutils import temporary_files_path, config, remove
 from h2o.estimators.coxph import H2OCoxProportionalHazardsEstimator


### PR DESCRIPTION
Fixes http://jenkins.h2o.local:8080/blue/rest/organizations/jenkins/pipelines/H2Oai-DriverlessAI/pipelines/dai-native-pipeline/branches/PR-33400/runs/13/nodes/152/steps/238/log/?start=0

```
 assert parsed_globals_output.strip() == global_imports.strip()
[2024-08-06T17:13:19.354Z] AssertionError: assert "_global_modu...o==3.46.0.2']" == "_global_modu...o==3.46.0.4']"
[2024-08-06T17:13:19.354Z]   
[2024-08-06T17:13:19.354Z]   - _global_modules_needed_by_name = ['h2o==3.46.0.4']
[2024-08-06T17:13:19.354Z]   ?                                                ^
[2024-08-06T17:13:19.354Z]   + _global_modules_needed_by_name = ['h2o==3.46.0.2']
```