### PR TITLE
Add missing import `model_gam.py`

### DIFF
--- a/models/mli/model_gam.py
+++ b/models/mli/model_gam.py
@@ -191,6 +191,9 @@ class GAM(CustomModel):
                 raise IgnoreError('On entry to DLASCL parameter number') from e
             raise
         except:
+            import traceback
+            import sys
+
             t, v, tb = sys.exc_info()
             ex = ''.join(traceback.format_exception(t, v, tb))
             print(ex)


### PR DESCRIPTION
This fixes 
```
Traceback (most recent call last):
  File "h2oaicore/models_main.py", line 3756, in h2oaicore.models_main.MainModel.fit_base
  File "h2oaicore/models_main.py", line 3763, in h2oaicore.models_main.MainModel.fit_base
  File "tmp/h2oai/contrib/models/model_gam.py", line 194, in fit
    t, v, tb = sys.exc_info()
```
in
http://jenkins.h2o.local:8080/job/H2Oai-DriverlessAI/job/dai-native-pipeline-nightly/job/dev/1796/testReport/tests.test_integration/test_weather/Testing_on_x86_64___CUDA_11_8_0_tests_integration_customa___test_regression_accuracy6_tt_scan_5230b_log_noclip_/