### PR TITLE
Fix dataset download URL in `TestData` recipe

### DIFF
--- a/data/data_test.py
+++ b/data/data_test.py
@@ -11,7 +11,7 @@ from h2oaicore.systemutils import user_dir
 
 
 class TestData(CustomData):
-    url = "http://archive.ics.uci.edu/static/public/53/iris.zip"
+    url = "https://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris.zip"
     dataset_name = "iris.data"
 
     @staticmethod

--- a/data/data_test.py
+++ b/data/data_test.py
@@ -11,6 +11,7 @@ from h2oaicore.systemutils import user_dir
 
 
 class TestData(CustomData):
+    # Archived copy of the http://archive.ics.uci.edu/static/public/53/iris.zip
     url = "https://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris.zip"
     dataset_name = "iris.data"
 


### PR DESCRIPTION
fixes http://jenkins.h2o.local:8080/blue/rest/organizations/jenkins/pipelines/H2Oai-DriverlessAI/pipelines/dai-native-pipeline/branches/PR-33582/runs/28/nodes/173/steps/226/log/?start=0 failing because `http://archive.ics.uci.edu/static/public/53/iris.zip` gives a 502.

```
'concurrent.futures.process._RemoteTraceback: \n"""\nTraceback (most recent call last):\n  File "/home/poorna/Documents/h2oai/h2oai/h2oaicore/systemutils.py", line 8526, in __traced_func\n    val = func(*args, **kwargs)\n          ^^^^^^^^^^^^^^^^^^^^^\n  File "tmp/h2oai/contrib/data/data_test_7495cf0c_content.py", line 29, in create_data\n    zip_file = download(TestData.url, dest_path=temp_path)\n               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/poorna/Documents/h2oai/h2oai/h2oaicore/systemutils_more.py", line 510, in download\n    raise requests.exceptions.RequestException(msg)\nrequests.exceptions.RequestException: Cannot get url http://archive.ics.uci.edu/static/public/53/iris.zip, code: 502, reason: Bad Gateway\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/home/poorna/minicondadai_py311/lib/python3.11/concurrent/futures/process.py", line 261, in _process_worker\n    r = call_item.fn(*call_item.args, **call_item.kwargs)\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/poorna/Documents/h2oai/h2oai/h2oaicore/systemutils.py", line 8869, in traced_func_without_task_or_usesgpu\n    return _traced_func(func, False, *args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/poorna/Documents/h2oai/h2oai/h2oaicore/systemutils.py", line 8437, in _traced_func\n    return __traced_func(func, argument, *args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/poorna/Documents/h2oai/h2oai/h2oaicore/systemutils.py", line 8550, in __traced_func\n    raise DAIFallBackError(str(the_ex))\nh2oaicore.systemutils.DAIFallBackError: Cannot get url http://archive.ics.uci.edu/static/public/53/iris.zip, code: 502, reason: Bad Gateway\n"""\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File "/home/poorna/Documents/h2oai/h2oai/h2oaicore/utils.py", line 2006, in _get_data\n    outputs = call_subprocess_onetask(func, args, kwargs)\n              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/poorna/Documents/h2oai/h2oai/h2oaicore/systemutils.py", line 7274, in call_subprocess_onetask\n    p.finish()\n  File "/home/poorna/Documents/h2oai/h2oai/h2oaicore/systemutils.py", line 7420, in finish\n    return super().finish(out=out, sleeptouse=sleeptouse, timeout=timeout, trying=trying)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/poorna/Documents/h2oai/h2oai/h2oaicore/systemutils.py", line 5175, in finish\n    raise e\n  File "/home/poorna/Documents/h2oai/h2oai/h2oaicore/systemutils.py", line 5155, in finish\n    p_tf_2.self_finish(out=out, sleeptouse=sleeptouse, timeout=timeout, trying=trying)\n  File "/home/poorna/Documents/h2oai/h2oai/h2oaicore/systemutils.py", line 5233, in self_finish\n    return self._self_finish(out=out, sleeptouse=sleeptouse, timeout=timeout, trying=trying)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/poorna/Documents/h2oai/h2oai/h2oaicore/systemutils.py", line 5271, in _self_finish\n    self.try_get_internal(trying, self.max_workers, self.future, outuse, self.processor,\n  File "/home/poorna/Documents/h2oai/h2oai/h2oaicore/systemutils.py", line 4207, in try_get_internal\n    res = future[wfut].result(timeout=sleeptouse)\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/poorna/minicondadai_py311/lib/python3.11/concurrent/futures/_base.py", line 456, in result\n    return self.__get_result()\n           ^^^^^^^^^^^^^^^^^^^\n  File "/home/poorna/minicondadai_py311/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result\n    raise self._exception\nh2oaicore.systemutils.DAIFallBackError: Cannot get url http://archive.ics.uci.edu/static/public/53/iris.zip, code: 502, reason: Bad Gateway\n'
```