### PR TITLE
Enforce fixed dask

### DIFF
--- a/models/timeseries/autoarima_parallel.py
+++ b/models/timeseries/autoarima_parallel.py
@@ -89,10 +89,11 @@ class AutoARIMAParallelModel(CustomTimeSeriesModel):
             '%s/httpstan-4.12.0%s' % (_root_path, _suffix),
             '%s/prophet-1.1.5%s' % (_root_path, _suffix),
             "statsforecast==1.7.4",
+            "dask==2024.12.1",
         ]
     else:
         _modules_needed_by_name = ['holidays==0.47', 'convertdate', 'lunarcalendar', 'pystan==3.9.1',
-                                   'prophet==1.1.5', 'statsforecast==1.7.4']
+                                   'prophet==1.1.5', 'statsforecast==1.7.4', 'dask==2024.12.1',]
 
     def set_default_params(
             self, accuracy=None, time_tolerance=None, interpretability=None, **kwargs

--- a/models/timeseries/nixtla_arimax.py
+++ b/models/timeseries/nixtla_arimax.py
@@ -74,7 +74,7 @@ class AutoARIMAParallelModel(CustomTimeSeriesModel):
     _parallel_task = True
     _testing_can_skip_failure = False  # ensure tested as if shouldn't fail
 
-    _modules_needed_by_name = ['statsforecast==1.7.4']
+    _modules_needed_by_name = ['statsforecast==1.7.4', 'dask==2024.12.1',]
     
     @staticmethod
     def is_enabled():

--- a/models/timeseries/nixtla_ces.py
+++ b/models/timeseries/nixtla_ces.py
@@ -74,7 +74,7 @@ class AutoCESParallelModel(CustomTimeSeriesModel):
     _parallel_task = True
     _testing_can_skip_failure = False  # ensure tested as if shouldn't fail
 
-    _modules_needed_by_name = ['statsforecast==1.7.4']
+    _modules_needed_by_name = ['statsforecast==1.7.4', 'dask==2024.12.1',]
     
     @staticmethod
     def is_enabled():

--- a/models/timeseries/nixtla_ets.py
+++ b/models/timeseries/nixtla_ets.py
@@ -74,7 +74,7 @@ class AutoETSParallelModel(CustomTimeSeriesModel):
     _parallel_task = True
     _testing_can_skip_failure = False  # ensure tested as if shouldn't fail
 
-    _modules_needed_by_name = ['statsforecast==1.7.4']
+    _modules_needed_by_name = ['statsforecast==1.7.4', 'dask==2024.12.1',]
     
     @staticmethod
     def is_enabled():

--- a/models/timeseries/nixtla_theta.py
+++ b/models/timeseries/nixtla_theta.py
@@ -74,7 +74,7 @@ class AutoThetaParallelModel(CustomTimeSeriesModel):
     _parallel_task = True
     _testing_can_skip_failure = False  # ensure tested as if shouldn't fail
 
-    _modules_needed_by_name = ['statsforecast==1.7.4']
+    _modules_needed_by_name = ['statsforecast==1.7.4', 'dask==2024.12.1',]
     
     @staticmethod
     def is_enabled():


### PR DESCRIPTION
Address http://jenkins.h2o.local:8080/job/driverlessai/job/Nightly-Pipeline/job/dev/48/testReport/junit/tests.test_scoring/test_scoring_package/Testing_on_x86_64___CUDA_11_8_0_tests_scoring_customa___test_scoring_regression_1_Ymd_ts_causal_5f743_/ 
and similar error due to

```
  File "/opt/h2oai/dai/python/lib/python3.11/site-packages/dask/utils.py", line 809, in _derived_from
    method_args = get_named_args(method)
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/h2oai/dai/python/lib/python3.11/site-packages/dask/utils.py", line 570, in get_named_args
    s = inspect.signature(func)
        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/h2oai/dai/python/lib/python3.11/inspect.py", line 3263, in signature
    return Signature.from_callable(obj, follow_wrapped=follow_wrapped,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/h2oai/dai/python/lib/python3.11/inspect.py", line 3011, in from_callable
    return _signature_from_callable(obj, sigcls=cls,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/h2oai/dai/python/lib/python3.11/inspect.py", line 2599, in _signature_from_callable
    call = _descriptor_get(call, obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/h2oai/dai/python/lib/python3.11/inspect.py", line 2432, in _descriptor_get
    return get(descriptor, obj, type(obj))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: descriptor '__call__' for 'type' objects doesn't apply to a 'property' object
```