### PR TITLE
Revert dask upgrade

### DIFF
--- a/models/timeseries/autoarima_parallel.py
+++ b/models/timeseries/autoarima_parallel.py
@@ -89,10 +89,11 @@ class AutoARIMAParallelModel(CustomTimeSeriesModel):
             '%s/httpstan-4.12.0%s' % (_root_path, _suffix),
             '%s/prophet-1.1.5%s' % (_root_path, _suffix),
             "statsforecast==1.7.4",
+            "dask==2024.12.1",
         ]
     else:
         _modules_needed_by_name = ['holidays==0.47', 'convertdate', 'lunarcalendar', 'pystan==3.9.1',
-                                   'prophet==1.1.5', 'statsforecast==1.7.4']
+                                   'prophet==1.1.5', 'statsforecast==1.7.4', 'dask==2024.12.1',]
 
     def set_default_params(
             self, accuracy=None, time_tolerance=None, interpretability=None, **kwargs

--- a/models/timeseries/nixtla_arimax.py
+++ b/models/timeseries/nixtla_arimax.py
@@ -74,7 +74,7 @@ class AutoARIMAParallelModel(CustomTimeSeriesModel):
     _parallel_task = True
     _testing_can_skip_failure = False  # ensure tested as if shouldn't fail
 
-    _modules_needed_by_name = ['statsforecast==1.7.4']
+    _modules_needed_by_name = ['statsforecast==1.7.4', 'dask==2024.12.1',]
     
     @staticmethod
     def is_enabled():

--- a/models/timeseries/nixtla_ces.py
+++ b/models/timeseries/nixtla_ces.py
@@ -74,7 +74,7 @@ class AutoCESParallelModel(CustomTimeSeriesModel):
     _parallel_task = True
     _testing_can_skip_failure = False  # ensure tested as if shouldn't fail
 
-    _modules_needed_by_name = ['statsforecast==1.7.4']
+    _modules_needed_by_name = ['statsforecast==1.7.4', 'dask==2024.12.1',]
     
     @staticmethod
     def is_enabled():

--- a/models/timeseries/nixtla_ets.py
+++ b/models/timeseries/nixtla_ets.py
@@ -74,7 +74,7 @@ class AutoETSParallelModel(CustomTimeSeriesModel):
     _parallel_task = True
     _testing_can_skip_failure = False  # ensure tested as if shouldn't fail
 
-    _modules_needed_by_name = ['statsforecast==1.7.4']
+    _modules_needed_by_name = ['statsforecast==1.7.4', 'dask==2024.12.1',]
     
     @staticmethod
     def is_enabled():

--- a/models/timeseries/nixtla_theta.py
+++ b/models/timeseries/nixtla_theta.py
@@ -74,7 +74,7 @@ class AutoThetaParallelModel(CustomTimeSeriesModel):
     _parallel_task = True
     _testing_can_skip_failure = False  # ensure tested as if shouldn't fail
 
-    _modules_needed_by_name = ['statsforecast==1.7.4']
+    _modules_needed_by_name = ['statsforecast==1.7.4', 'dask==2024.12.1',]
     
     @staticmethod
     def is_enabled():


### PR DESCRIPTION
We cannot upgrade Dask in DAI, so the issue was fixed with a hotfix.


This reverts commit db01f405a7789dd9784e937fe9681707d906d7fa, reversing changes made to 174354eeaa88fc40647b56335e8e9a88aaa853fb.