### PR TITLE
[BUG] Fix wrong max_features

### DIFF
--- a/models/mli/model_skopes_rules.py
+++ b/models/mli/model_skopes_rules.py
@@ -31,7 +31,7 @@ class SKOPE_RULES(CustomModel):
                            max_depth_duplication=None, n_estimators=10,
                            precision_min=0.5, recall_min=0.01, max_samples=0.8,
                            max_samples_features=1.0, max_depth=3,
-                           max_features="auto", min_samples_split=2,
+                           max_features=None, min_samples_split=2,
                            bootstrap=False, bootstrap_features=False)
 
     def mutate_params(self, accuracy=10, **kwargs):
@@ -43,7 +43,7 @@ class SKOPE_RULES(CustomModel):
             max_samples = [0.5, 0.8, 1.0]
             max_samples_features = [0.5, 0.8, 1.0]
             max_depth = [3, 4, 5]
-            max_features = ["sqrt", "log2", "auto"]
+            max_features = ["sqrt", "log2", None]
             min_samples_split = [2, 11, 21]
             bootstrap = [True, False]
             bootstrap_features = [True, False]
@@ -55,7 +55,7 @@ class SKOPE_RULES(CustomModel):
             max_samples = [0.8, 1.0]
             max_samples_features = [1.0]
             max_depth = [3, 4]
-            max_features = ["sqrt", "log2", "auto"]
+            max_features = ["sqrt", "log2", None]
             min_samples_split = [2, 5, 11]
             bootstrap = [True, False]
             bootstrap_features = [True, False]
@@ -67,7 +67,7 @@ class SKOPE_RULES(CustomModel):
             max_samples = [0.8, 1.0]
             max_samples_features = [0.8, 1.0]
             max_depth = [3, 4]
-            max_features = ["auto"]
+            max_features = [None]
             min_samples_split = [2]
             bootstrap = [True, False]
             bootstrap_features = [True, False]


### PR DESCRIPTION
```
2025-04-13 09:53:00,162 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING| During handling of the above exception, another exception occurred:
2025-04-13 09:53:00,162 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING| 
2025-04-13 09:53:00,163 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING| Traceback (most recent call last):
2025-04-13 09:53:00,163 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "h2oaicore/auto_dl.py", line 2316, in h2oaicore.auto_dl.do_auto_dl_subprocess
2025-04-13 09:53:00,164 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "h2oaicore/ga_population.py", line 2822, in h2oaicore.ga_population.Population.make_final_model
2025-04-13 09:53:00,164 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "h2oaicore/systemutils.py", line 8480, in h2oaicore.systemutils._trace.f
2025-04-13 09:53:00,164 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "h2oaicore/systemutils.py", line 8692, in h2oaicore.systemutils._traced_func
2025-04-13 09:53:00,165 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "h2oaicore/systemutils.py", line 8794, in h2oaicore.systemutils.__traced_func
2025-04-13 09:53:00,165 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING| RuntimeError: Single model failed, not expected in testing, earlier error should have caught. Traceback (most recent call last):
2025-04-13 09:53:00,165 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "h2oaicore/models_main.py", line 3757, in h2oaicore.models_main.MainModel.fit_base
2025-04-13 09:53:00,166 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "h2oaicore/models_main.py", line 3764, in h2oaicore.models_main.MainModel.fit_base
2025-04-13 09:53:00,166 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "tmp/h2oai/contrib/models/model_skopes_rules.py", line 208, in fit
2025-04-13 09:53:00,166 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|     model.fit(np.array(X), np.array(y))
2025-04-13 09:53:00,167 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "/h2oai/tmp/h2oai/contrib/env/lib/python3.11/site-packages/skrules/skope_rules.py", line 321, in fit
2025-04-13 09:53:00,167 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|     clf.fit(X, y)
2025-04-13 09:53:00,167 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "/opt/h2oai/dai/python/lib/python3.11/site-packages/sklearn/utils/validation.py", line 66, in inner_f
2025-04-13 09:53:00,168 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|     return f(*args, **kwargs)
2025-04-13 09:53:00,168 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|            ^^^^^^^^^^^^^^^^^^
2025-04-13 09:53:00,168 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "/opt/h2oai/dai/python/lib/python3.11/site-packages/sklearn/base.py", line 1475, in wrapper
2025-04-13 09:53:00,169 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|     return fit_method(estimator, *args, **kwargs)
2025-04-13 09:53:00,170 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-04-13 09:53:00,171 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "/opt/h2oai/dai/python/lib/python3.11/site-packages/sklearn/ensemble/_bagging.py", line 402, in fit
2025-04-13 09:53:00,171 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|     return self._fit(X, y, max_samples=self.max_samples, **fit_params)
2025-04-13 09:53:00,171 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-04-13 09:53:00,171 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "/opt/h2oai/dai/python/lib/python3.11/site-packages/sklearn/ensemble/_bagging.py", line 545, in _fit
2025-04-13 09:53:00,171 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|     all_results = Parallel(
2025-04-13 09:53:00,172 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|                   ^^^^^^^^^
2025-04-13 09:53:00,172 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "/opt/h2oai/dai/python/lib/python3.11/site-packages/sklearn/utils/parallel.py", line 74, in __call__
2025-04-13 09:53:00,172 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|     return super().__call__(iterable_with_config)
2025-04-13 09:53:00,173 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-04-13 09:53:00,173 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "/opt/h2oai/dai/python/lib/python3.11/site-packages/joblib/parallel.py", line 1918, in __call__
2025-04-13 09:53:00,173 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|     return output if self.return_generator else list(output)
2025-04-13 09:53:00,174 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|                                                 ^^^^^^^^^^^^
2025-04-13 09:53:00,174 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "/opt/h2oai/dai/python/lib/python3.11/site-packages/joblib/parallel.py", line 1847, in _get_sequential_output
2025-04-13 09:53:00,174 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|     res = func(*args, **kwargs)
2025-04-13 09:53:00,175 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|           ^^^^^^^^^^^^^^^^^^^^^
2025-04-13 09:53:00,175 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "/opt/h2oai/dai/python/lib/python3.11/site-packages/sklearn/utils/parallel.py", line 136, in __call__
2025-04-13 09:53:00,175 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|     return self.function(*args, **kwargs)
2025-04-13 09:53:00,176 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-04-13 09:53:00,176 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "/opt/h2oai/dai/python/lib/python3.11/site-packages/sklearn/ensemble/_bagging.py", line 187, in _parallel_build_estimators
2025-04-13 09:53:00,176 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|     estimator_fit(X_, y, **fit_params_)
2025-04-13 09:53:00,176 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "/opt/h2oai/dai/python/lib/python3.11/site-packages/sklearn/base.py", line 1468, in wrapper
2025-04-13 09:53:00,177 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|     estimator._validate_params()
2025-04-13 09:53:00,177 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "/opt/h2oai/dai/python/lib/python3.11/site-packages/sklearn/base.py", line 668, in _validate_params
2025-04-13 09:53:00,177 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|     validate_parameter_constraints(
2025-04-13 09:53:00,177 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|   File "/opt/h2oai/dai/python/lib/python3.11/site-packages/sklearn/utils/_param_validation.py", line 95, in validate_parameter_constraints
2025-04-13 09:53:00,177 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING|     raise InvalidParameterError(
2025-04-13 09:53:00,178 C: 41% D:481.5GB M:77.8GB  NODE:SERVER      1824   WARNING| sklearn.utils._param_validation.InvalidParameterError: The 'max_features' parameter of DecisionTreeClassifier must be an int in the range [1, inf), a float in the range (0.0, 1.0], a str among {'log2', 'sqrt'} or None. Got 'auto' instead.
```