### PR TITLE
Fix feature_selection_* mlxtend install: pin matplotlib to env version

### DIFF
--- a/data/feature_selection_backward.py
+++ b/data/feature_selection_backward.py
@@ -30,7 +30,10 @@ CV = 5
 
 
 class BackwardFeatureSelection(CustomData):
-    _modules_needed_by_name = ["mlxtend"]
+    # Pin matplotlib to the DAI env version (conda matplotlib-base==3.8.3) so pip does not
+    # try to upgrade it while installing mlxtend; that upgrade fails in CI when pip cannot
+    # uninstall the conda matplotlib-base. Keep this in sync with DAI's matplotlib-base pin.
+    _modules_needed_by_name = ["matplotlib==3.8.3", "mlxtend==0.23.4"]
 
     @staticmethod
     def create_data(X: dt.Frame = None) -> pd.DataFrame:

--- a/data/feature_selection_bidirectional.py
+++ b/data/feature_selection_bidirectional.py
@@ -30,7 +30,10 @@ CV = 5
 
 
 class BidirectionalFeatureSelection(CustomData):
-    _modules_needed_by_name = ["mlxtend"]
+    # Pin matplotlib to the DAI env version (conda matplotlib-base==3.8.3) so pip does not
+    # try to upgrade it while installing mlxtend; that upgrade fails in CI when pip cannot
+    # uninstall the conda matplotlib-base. Keep this in sync with DAI's matplotlib-base pin.
+    _modules_needed_by_name = ["matplotlib==3.8.3", "mlxtend==0.23.4"]
 
     @staticmethod
     def create_data(X: dt.Frame = None) -> pd.DataFrame:

--- a/data/feature_selection_exhaustive.py
+++ b/data/feature_selection_exhaustive.py
@@ -32,7 +32,10 @@ CV = 5
 
 
 class ExhaustiveFeatureSelection(CustomData):
-    _modules_needed_by_name = ["mlxtend"]
+    # Pin matplotlib to the DAI env version (conda matplotlib-base==3.8.3) so pip does not
+    # try to upgrade it while installing mlxtend; that upgrade fails in CI when pip cannot
+    # uninstall the conda matplotlib-base. Keep this in sync with DAI's matplotlib-base pin.
+    _modules_needed_by_name = ["matplotlib==3.8.3", "mlxtend==0.23.4"]
 
     @staticmethod
     def create_data(X: dt.Frame = None) -> pd.DataFrame:

--- a/data/feature_selection_forward.py
+++ b/data/feature_selection_forward.py
@@ -30,7 +30,10 @@ CV = 5
 
 
 class ForwardFeatureSelection(CustomData):
-    _modules_needed_by_name = ["mlxtend"]
+    # Pin matplotlib to the DAI env version (conda matplotlib-base==3.8.3) so pip does not
+    # try to upgrade it while installing mlxtend; that upgrade fails in CI when pip cannot
+    # uninstall the conda matplotlib-base. Keep this in sync with DAI's matplotlib-base pin.
+    _modules_needed_by_name = ["matplotlib==3.8.3", "mlxtend==0.23.4"]
 
     @staticmethod
     def create_data(X: dt.Frame = None) -> pd.DataFrame:


### PR DESCRIPTION
The four feature_selection recipes declared `_modules_needed_by_name=["mlxtend"]`. mlxtend requires matplotlib>=3.0.0; with matplotlib unpinned, pip pulls the latest (e.g. 3.10.9) and tries to replace the env's conda matplotlib-base==3.8.3, then fails uninstalling it in CI ("Failed to get required package mlxtend") -> acceptance fails in test_repo_download_specific.

Pin matplotlib to the env version alongside mlxtend:
  _modules_needed_by_name = ["matplotlib==3.8.3", "mlxtend==0.23.4"]
so pip keeps matplotlib at 3.8.3 (already satisfied -> no upgrade, no uninstall) and just installs mlxtend. Keep the matplotlib pin in sync with DAI's matplotlib-base.