### PR TITLE
Fix CalibratedClassifier sigmoid/isotonic calibration on float32 models

### DIFF
--- a/models/algorithms/calibratedClassifier.py
+++ b/models/algorithms/calibratedClassifier.py
@@ -19,7 +19,7 @@ class SklearnWrapper:  # to trick CalibratedClassifierCV from sklearn
         self.classes_ = classes
 
     def predict_proba(self, X):
-        return self.model.predict_simple_base(X)
+        return self.model.predict_simple_base(X).astype(np.float64)
 
     def fit(X, y):  # SKLearn checks if this method exists in Estimator
         pass


### PR DESCRIPTION
sklearn 1.5.x CyHalfBinomialLoss requires float64 buffers; DAI models' predict_simple_base returns float32, causing a Cython buffer dtype mismatch during calibrator.fit(). Cast to float64 in SklearnWrapper.predict_proba.