### PR TITLE
Bump pillow pin to 12.3.0 to match DAI CVE fix

### DIFF
--- a/models/mli/model_ebm.py
+++ b/models/mli/model_ebm.py
@@ -32,7 +32,7 @@ class EBMModel(CustomModel):
         "Unified Framework for Machine Learning Interpretability. "
         "URL https://arxiv.org/pdf/1909.09223.pdf"
     )
-    _modules_needed_by_name = ["pillow==12.1.0", "interpret==0.6.1"]
+    _modules_needed_by_name = ["pillow==12.3.0", "interpret==0.6.1"]
 
     @staticmethod
     def do_acceptance_test():

--- a/transformers/image/image_ocr_transformer.py
+++ b/transformers/image/image_ocr_transformer.py
@@ -7,7 +7,7 @@ import numpy as np
 class ImageOCRTextTransformer(CustomTransformer):
     _unsupervised = True
 
-    _modules_needed_by_name = ['pillow==12.1.0', "pytesseract==0.3.10"]
+    _modules_needed_by_name = ['pillow==12.3.0', "pytesseract==0.3.10"]
     _parallel_task = True  # if enabled, params_base['n_jobs'] will be >= 1 (adaptive to system), otherwise 1
     _can_use_gpu = True  # if enabled, will use special job scheduler for GPUs
     _can_use_multi_gpu = True  # if enabled, can get access to multiple GPUs for single transformer (experimental)

--- a/transformers/image/image_url_transformer.py
+++ b/transformers/image/image_url_transformer.py
@@ -16,7 +16,7 @@ class MyImgTransformer(TensorFlowModel, CustomTransformer):
 
     # Need Pillow before nlp imports keras, else when here too late.
     # I.e. wasn't enough to put keras imports inside fit/transform to delay after Pillow installed
-    _modules_needed_by_name = ['pillow==12.1.0']
+    _modules_needed_by_name = ['pillow==12.3.0']
     _tensorflow = True
     _mojo = False
     _parallel_task = True  # assumes will use n_jobs in params_base


### PR DESCRIPTION
DAI upgraded pillow to 12.3.0 (CVE fixes). The recipe loader asserts each recipe's `_modules_needed_by_nam`e pin exactly matches DAI's installed version, so `pillow==12.1.0` in these image/EBM recipes fails to load. Bump to 12.3.0.