### PR TITLE
DAI CI test failure fix after numpy upgrade

### DIFF
--- a/models/algorithms/extremeClassifier.py
+++ b/models/algorithms/extremeClassifier.py
@@ -40,7 +40,7 @@ class HashLabel():
                     md5.update(str(np.random.randint(np.iinfo(np.int16).max)).encode('utf-8'))
                     self.mapped_classes[c, r] = int(md5.hexdigest(), 16) % self.B
 
-            unique_rows = np.vstack({tuple(row) for row in self.mapped_classes})
+            unique_rows = np.unique(self.mapped_classes, axis=0)
             maping_created = unique_rows.shape != self.mapped_classes.shape
 
     def transform(self, labels):


### PR DESCRIPTION
DAI side CI failed due to below error:

```
FAILED tests/test_scoring/test_scoring_package.py::test_scoring_multiclass_1[917f4] - RuntimeError: Experiment_name: test_scoring_multiclass_1_917f4_b33c Experiment_id: None model_key: wibasiki model_desc: None model_dir: None
Traceback (most recent call last):
  File "/h2oai/tests/test_scoring/test_scoring_package.py", line 2087, in run_scoring_test
    job = h2o._wait_for_model(model_key)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/h2oai/h2oai_client/protocol.py", line 1586, in _wait_for_model
    raise RuntimeError(self._format_server_error(job.error))
RuntimeError: Driverless AI Server reported an error: DriverlessAI Error.  Please send experiment logs to H2O.ai support (support@h2o.ai). Experiment ID: wibasiki
 Error: 
concurrent.futures.process._RemoteTraceback: 
"""
concurrent.futures.process._RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/models_main.py", line 3780, in fit_base
    ret = self.fit(X, y, sample_weight, eval_set, sample_weight_eval_set, **kwargs_to_use)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 104, in fit
    y_hashed = hashL.fit_transform(y_)
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 56, in fit_transform
    self.fit(labels)
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 43, in fit
    unique_rows = np.vstack({tuple(row) for row in self.mapped_classes})
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/numpy/core/shape_base.py", line 216, in _vhstack_dispatcher
    return _arrays_for_stack_dispatcher(tup)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/numpy/core/shape_base.py", line 209, in _arrays_for_stack_dispatcher
    raise TypeError('arrays to stack must be passed as a "sequence" type '
TypeError: arrays to stack must be passed as a "sequence" type such as list or tuple.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 10138, in __traced_func
    val = func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/models_main.py", line 8792, in fit_model
    self.fit_base(X=train_X, y=train_y, **train_kwargs, **fit_params)
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/models_main.py", line 3860, in fit_base
    raise e.__class__(str(ex))
TypeError: Traceback (most recent call last):
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/models_main.py", line 3780, in fit_base
    ret = self.fit(X, y, sample_weight, eval_set, sample_weight_eval_set, **kwargs_to_use)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 104, in fit
    y_hashed = hashL.fit_transform(y_)
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 56, in fit_transform
    self.fit(labels)
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 43, in fit
    unique_rows = np.vstack({tuple(row) for row in self.mapped_classes})
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/numpy/core/shape_base.py", line 216, in _vhstack_dispatcher
    return _arrays_for_stack_dispatcher(tup)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/numpy/core/shape_base.py", line 209, in _arrays_for_stack_dispatcher
    raise TypeError('arrays to stack must be passed as a "sequence" type '
TypeError: arrays to stack must be passed as a "sequence" type such as list or tuple.


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 10138, in __traced_func
    val = func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/ga_population.py", line 4361, in build_cv_model_subprocess
    MainModel.fit_predict_imp(
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/models_main.py", line 8896, in fit_predict_imp
    model = model.fit_model(params_base=params_base,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 9843, in f
    val = _traced_func(func, argument, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 10055, in _traced_func
    return __traced_func(func, argument, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 10157, in __traced_func
    raise e.__class__(str(the_ex))
TypeError: Traceback (most recent call last):
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/models_main.py", line 3780, in fit_base
    ret = self.fit(X, y, sample_weight, eval_set, sample_weight_eval_set, **kwargs_to_use)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 104, in fit
    y_hashed = hashL.fit_transform(y_)
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 56, in fit_transform
    self.fit(labels)
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 43, in fit
    unique_rows = np.vstack({tuple(row) for row in self.mapped_classes})
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/numpy/core/shape_base.py", line 216, in _vhstack_dispatcher
    return _arrays_for_stack_dispatcher(tup)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/numpy/core/shape_base.py", line 209, in _arrays_for_stack_dispatcher
    raise TypeError('arrays to stack must be passed as a "sequence" type '
TypeError: arrays to stack must be passed as a "sequence" type such as list or tuple.


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/minicondadai_py311/envs/daienv/lib/python3.11/concurrent/futures/process.py", line 261, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 10457, in traced_func
    return _traced_func(func, True, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 10049, in _traced_func
    return __traced_func(func, argument, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 10157, in __traced_func
    raise e.__class__(str(the_ex))
TypeError: Traceback (most recent call last):
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/models_main.py", line 3780, in fit_base
    ret = self.fit(X, y, sample_weight, eval_set, sample_weight_eval_set, **kwargs_to_use)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 104, in fit
    y_hashed = hashL.fit_transform(y_)
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 56, in fit_transform
    self.fit(labels)
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 43, in fit
    unique_rows = np.vstack({tuple(row) for row in self.mapped_classes})
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/numpy/core/shape_base.py", line 216, in _vhstack_dispatcher
    return _arrays_for_stack_dispatcher(tup)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/numpy/core/shape_base.py", line 209, in _arrays_for_stack_dispatcher
    raise TypeError('arrays to stack must be passed as a "sequence" type '
TypeError: arrays to stack must be passed as a "sequence" type such as list or tuple.

"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 10138, in __traced_func
    val = func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/ga_population.py", line 6136, in train
    p_train.submit_tryget(logger, traced_func,
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 6602, in submit_tryget
    return self._submit_tryget(logger, function, out=out, justcount=justcount,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 6657, in _submit_tryget
    pool_forsubmit.submit(function, out=out, justcount=justcount,
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 6526, in submit
    pool_forsubmit = self.pick_update_pool(needs_isolation=needs_isolation, do_check_stall=do_check_stall,
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 7164, in pick_update_pool
    raise e
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 7133, in pick_update_pool
    p_tf_2.finish(trying=0)
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 6784, in finish
    raise e
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 6764, in finish
    p_tf_2.self_finish(out=out, sleeptouse=sleeptouse, timeout=timeout, trying=trying)
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 6842, in self_finish
    return self._self_finish(out=out, sleeptouse=sleeptouse, timeout=timeout, trying=trying)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 6880, in _self_finish
    self.try_get_internal(trying, self.max_workers, self.future, outuse, self.processor,
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 5816, in try_get_internal
    res = future[wfut].result(timeout=sleeptouse)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
TypeError: Traceback (most recent call last):
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/models_main.py", line 3780, in fit_base
    ret = self.fit(X, y, sample_weight, eval_set, sample_weight_eval_set, **kwargs_to_use)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 104, in fit
    y_hashed = hashL.fit_transform(y_)
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 56, in fit_transform
    self.fit(labels)
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 43, in fit
    unique_rows = np.vstack({tuple(row) for row in self.mapped_classes})
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/numpy/core/shape_base.py", line 216, in _vhstack_dispatcher
    return _arrays_for_stack_dispatcher(tup)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/numpy/core/shape_base.py", line 209, in _arrays_for_stack_dispatcher
    raise TypeError('arrays to stack must be passed as a "sequence" type '
TypeError: arrays to stack must be passed as a "sequence" type such as list or tuple.


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 10138, in __traced_func
    val = func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/ga_population.py", line 5023, in _score_population
    train(population=population,
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 9843, in f
    val = _traced_func(func, argument, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 10055, in _traced_func
    return __traced_func(func, argument, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 10157, in __traced_func
    raise e.__class__(str(the_ex))
TypeError: Traceback (most recent call last):
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/models_main.py", line 3780, in fit_base
    ret = self.fit(X, y, sample_weight, eval_set, sample_weight_eval_set, **kwargs_to_use)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 104, in fit
    y_hashed = hashL.fit_transform(y_)
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 56, in fit_transform
    self.fit(labels)
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 43, in fit
    unique_rows = np.vstack({tuple(row) for row in self.mapped_classes})
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/numpy/core/shape_base.py", line 216, in _vhstack_dispatcher
    return _arrays_for_stack_dispatcher(tup)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/numpy/core/shape_base.py", line 209, in _arrays_for_stack_dispatcher
    raise TypeError('arrays to stack must be passed as a "sequence" type '
TypeError: arrays to stack must be passed as a "sequence" type such as list or tuple.


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/minicondadai_py311/envs/daienv/lib/python3.11/concurrent/futures/process.py", line 261, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 10481, in traced_func_without_task_or_usesgpu
    return _traced_func(func, False, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 10049, in _traced_func
    return __traced_func(func, argument, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 10157, in __traced_func
    raise e.__class__(str(the_ex))
TypeError: Traceback (most recent call last):
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/models_main.py", line 3780, in fit_base
    ret = self.fit(X, y, sample_weight, eval_set, sample_weight_eval_set, **kwargs_to_use)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 104, in fit
    y_hashed = hashL.fit_transform(y_)
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 56, in fit_transform
    self.fit(labels)
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 43, in fit
    unique_rows = np.vstack({tuple(row) for row in self.mapped_classes})
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/numpy/core/shape_base.py", line 216, in _vhstack_dispatcher
    return _arrays_for_stack_dispatcher(tup)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/numpy/core/shape_base.py", line 209, in _arrays_for_stack_dispatcher
    raise TypeError('arrays to stack must be passed as a "sequence" type '
TypeError: arrays to stack must be passed as a "sequence" type such as list or tuple.

"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/auto_dl.py", line 2246, in do_auto_dl_subprocess
    popinst.tune(
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/ga_population.py", line 1543, in tune
    tune_params_result = tune_params(
                         ^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/tuning.py", line 2238, in tune_params
    score_tuning_population(
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/tuning.py", line 3023, in score_tuning_population
    score_population(population=pop_try,
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/ga_population.py", line 4953, in score_population
    return call_subprocess_onetask(_score_population, args=args, kwargs=kwargs,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 8886, in call_subprocess_onetask
    p.finish()
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 9032, in finish
    return super().finish(out=out, sleeptouse=sleeptouse, timeout=timeout, trying=trying)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 6784, in finish
    raise e
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 6764, in finish
    p_tf_2.self_finish(out=out, sleeptouse=sleeptouse, timeout=timeout, trying=trying)
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 6842, in self_finish
    return self._self_finish(out=out, sleeptouse=sleeptouse, timeout=timeout, trying=trying)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 6880, in _self_finish
    self.try_get_internal(trying, self.max_workers, self.future, outuse, self.processor,
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/systemutils.py", line 5816, in try_get_internal
    res = future[wfut].result(timeout=sleeptouse)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
TypeError: Traceback (most recent call last):
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/h2oaicore/models_main.py", line 3780, in fit_base
    ret = self.fit(X, y, sample_weight, eval_set, sample_weight_eval_set, **kwargs_to_use)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 104, in fit
    y_hashed = hashL.fit_transform(y_)
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 56, in fit_transform
    self.fit(labels)
  File "tmp/h2oai/contrib/models/extremeClassifier.py", line 43, in fit
    unique_rows = np.vstack({tuple(row) for row in self.mapped_classes})
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/numpy/core/shape_base.py", line 216, in _vhstack_dispatcher
    return _arrays_for_stack_dispatcher(tup)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/minicondadai_py311/envs/daienv/lib/python3.11/site-packages/numpy/core/shape_base.py", line 209, in _arrays_for_stack_dispatcher
    raise TypeError('arrays to stack must be passed as a "sequence" type '
TypeError: arrays to stack must be passed as a "sequence" type such as list or tuple.

```
Experiment_name: test_scoring_multiclass_1_917f4_b33c Experiment_id: None model_key: wibasiki model_desc: None model_dir: None
============ 1 failed, 2 passed, 403 warnings in 1402.28s (0:23:22) ============
make: *** [make/tests.mk:849: test_scoring_custom_smoke] Error 1
make: Target 'test_stage_2' not remade because of errors.
SMOKE_TIMING_tests_seconds=1747
SMOKE_TIMING_total_seconds=1926
make: *** [Makefile:1751: test_pull_request_quick_x86_64-cb21af4f471fdb35717d7b75b5f1155b] Error 2
Error: Process completed with exit code 2.
```
